### PR TITLE
chore: add CODEOWNERS for Platform and Product

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS for all files
+* @translucent-ai/platform @translucent-ai/product


### PR DESCRIPTION
Add CODEOWNERS for common platform repos

This adds root CODEOWNERS applying to all files:

    * @translucent-ai/platform @translucent-ai/product

Teams:
- Platform: https://github.com/orgs/translucent-ai/teams/platform
- Product: https://github.com/orgs/translucent-ai/teams/product

Rationale: ensure coverage while team membership is limited.